### PR TITLE
HTTPS is now optionnal and disabled by default for vatlayer requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,18 @@ After installation, you'll also need to setup your site to use it. To do that, o
 Lastly, run `manage.py migrate` to create new tables in your database and `manage.py get_vat_rates` to populate them with initial data.
 
 
-Forcing non-secure API connection in production
------------------------------------------------
+Forcing secure API connection in production
+-------------------------------------------
 
-By default, `django-prices-vatlayer` uses the unsafe HTTP connection during development (`DEBUG = True`) and changes to HTTPS in production, to keep communication with the `vatlayer` API secure.
+By default, as HTTP is unavailable in the free vatlayer plan, `django-prices-vatlayer` uses the unsafe HTTP connection.
 
-However as HTTPS unavailable in vatlayer's free plan, you may preffer to force unsafe HTTP on your live site as well. To do so, just add following line to your `settings.py`:
+However, if you are using a paid plan of vatlayer, you may want to force secure HTTP on your live site. To do so, just add following line in your `settings.py`:
 
-`VATLAYER_API = 'http://apilayer.net/api/'`
+```python
+VATLAYER_USE_HTTPS = True
+```
 
-Remember that doing so may expose you to DNS poisoning and man-in-the-middle attacks and we recommend that `VATLAYER_API` is set to use the HTTPS.
+Remember that using insecure HTTP may expose you to DNS poisoning and man-in-the-middle attacks; we recommend that `VATLAYER_USE_HTTPS` is set to use the secure HTTP protocol.
 
 
 Updating VAT rates

--- a/README.md
+++ b/README.md
@@ -43,15 +43,15 @@ Lastly, run `manage.py migrate` to create new tables in your database and `manag
 Forcing secure API connection in production
 -------------------------------------------
 
-By default, as HTTP is unavailable in the free vatlayer plan, `django-prices-vatlayer` uses the unsafe HTTP connection.
+Because HTTPS is unavailable in the free vatlayer plan, `django-prices-vatlayer` uses the unsafe HTTP connection by default.
 
-However, if you are using a paid plan of vatlayer, you may want to force secure HTTP on your live site. To do so, just add following line in your `settings.py`:
+If you are using a paid plan, you can force the secure HTTP on your site by adding following line to your `settings.py`:
 
 ```python
 VATLAYER_USE_HTTPS = True
 ```
 
-Remember that using insecure HTTP may expose you to DNS poisoning and man-in-the-middle attacks; we recommend that `VATLAYER_USE_HTTPS` is set to use the secure HTTP protocol.
+Remember that not using HTTPS may expose you to DNS poisoning and man-in-the-middle attacks; we recommend enabling `VATLAYER_USE_HTTPS` in production sites.
 
 
 Updating VAT rates

--- a/django_prices_vatlayer/utils.py
+++ b/django_prices_vatlayer/utils.py
@@ -13,7 +13,9 @@ try:
 except AttributeError:
     raise ImproperlyConfigured('VATLAYER_ACCESS_KEY is required')
 
-PROTOCOL = 'http://' if settings.DEBUG else 'https://'
+USE_HTTPS = getattr(settings, 'VATLAYER_USE_HTTPS', False)
+
+PROTOCOL = 'https://' if USE_HTTPS else 'http://'
 DEFAULT_URL = PROTOCOL + 'apilayer.net/api/'
 
 VATLAYER_API = getattr(settings, 'VATLAYER_API', DEFAULT_URL)


### PR DESCRIPTION
This PR introduces a new settings: `VATLAYER_USE_HTTPS` which is set to `False` by default.

This closes #6.