### PR TITLE
fix: Rate limit error when executing requests too quickly

### DIFF
--- a/django_prices_vatlayer/utils.py
+++ b/django_prices_vatlayer/utils.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 
 import requests
+import time
 from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
@@ -45,6 +46,7 @@ def fetch_from_api(url, access_key=None):
             "pass access_key in params argument"
         )
     url = VATLAYER_API + url
+    time.sleep(5)
     response = requests.get(url, params={'access_key': access_key})
     return response.json()
 

--- a/django_prices_vatlayer/utils.py
+++ b/django_prices_vatlayer/utils.py
@@ -46,7 +46,6 @@ def fetch_from_api(url, access_key=None):
             "pass access_key in params argument"
         )
     url = VATLAYER_API + url
-    time.sleep(5)
     response = requests.get(url, params={'access_key': access_key})
     return response.json()
 
@@ -130,6 +129,7 @@ def get_tax_rate_types():
 def fetch_rates(access_key=None):
     json_response_rates = fetch_vat_rates(access_key=access_key)
     create_objects_from_json(json_response_rates)
+    time.sleep(5)
 
     json_response_types = fetch_rate_types(access_key=access_key)
     save_vat_rate_types(json_response_types)


### PR DESCRIPTION
I have created this very simple fix for the following error:

`django.core.exceptions.ImproperlyConfigured:`
```json
{"success": false, "error": {"code": 106, "type": "rate_limit_reached", "info": "You have exceeded the maximum rate limitation allowed on your subscription plan. Please refer to the \"Rate Limits\" section of the API Documentation for details. "}}
```

It seems the Vatlayer API prevents two fast consecutive requests. Therefore I've added a small delay between the requests.

For reference, the error that pops up in Saleor:
![Screenshot 2021-08-11 at 17 05 13](https://user-images.githubusercontent.com/18720368/129054268-c7b87654-b5f4-439b-ab07-7d3a436d62a2.png)
